### PR TITLE
Update bsconfig.json

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -13,6 +13,5 @@
       "type": "dev"
     }
   ],
-  "namespace": true,
   "refmt": 3
 }


### PR DESCRIPTION
Remove `namespace:true` so that the module is accessible as `Readline` when imported. Closes #1